### PR TITLE
Output denials in the future

### DIFF
--- a/policies/main.rego
+++ b/policies/main.rego
@@ -6,12 +6,22 @@ deny = {denial |
 	denial := data.policies[policy].deny[_]
 }
 
+future_deny = {denial |
+	skip_not_in_effect(policy)
+	data.policies[policy].deny[_]
+	denial := data.policies[policy].deny[_]
+}
+
 skip(test_name) {
 	data.config.policy.non_blocking_checks[_] == test_name
 }
 
-skip(policy_name) {
+skip_not_in_effect(policy_name) {
 	# Use the nanosecond epoch defined in the policy if present. Otherwise, use now.
 	when_ns := object.get(data.config.policy, ["when_ns"], time.now_ns())
 	data.policies[policy_name].effective_on > when_ns
+}
+
+skip(policy_name) {
+	skip_not_in_effect(policy_name)
 }

--- a/policies/main_test.rego
+++ b/policies/main_test.rego
@@ -58,3 +58,9 @@ test_policy_not_ignored_when_effective_missing {
 	# Verify that the policy is enforced by default
 	expected_error == deny with data.config.policy as policy_config
 }
+
+test_future_denial {
+	future := time.add_date(time.now_ns(), 0, 0, 1)
+	{{"msg": "It just feels like a bad day to do a release"}} == future_deny with data.config.policy as {"non_blocking_checks": all_tests - {"not_useful"}}
+		with data.policies.not_useful.effective_on as future
+}


### PR DESCRIPTION
Adds `future_deny` output computed over all policy checks that are not
currently in effect but will be in the future.